### PR TITLE
Added ROS CI by branch

### DIFF
--- a/.github/workflows/humble-ros.yml
+++ b/.github/workflows/humble-ros.yml
@@ -1,0 +1,25 @@
+name: CI-humble
+on:
+  push:
+    branches:
+      - 'humble'
+  pull_request:
+    branches:
+      - 'humble'
+  workflow_dispatch:
+    branches:
+      - '*'
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: humble, ROS_REPO: testing}
+          - {ROS_DISTRO: humble, ROS_REPO: main}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/master-ros.yml
+++ b/.github/workflows/master-ros.yml
@@ -1,0 +1,27 @@
+name: CI-master
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+  workflow_dispatch:
+    branches:
+      - '*'
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: melodic, ROS_REPO: testing}
+          - {ROS_DISTRO: melodic, ROS_REPO: main}
+          - {ROS_DISTRO: noetic, ROS_REPO: testing}
+          - {ROS_DISTRO: noetic, ROS_REPO: main}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/melodic-ros.yml
+++ b/.github/workflows/melodic-ros.yml
@@ -1,0 +1,25 @@
+name: CI-melodic
+on:
+  push:
+    branches:
+      - 'melodic'
+  pull_request:
+    branches:
+      - 'melodic'
+  workflow_dispatch:
+    branches:
+      - '*'
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: melodic, ROS_REPO: testing}
+          - {ROS_DISTRO: melodic, ROS_REPO: main}
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/.github/workflows/noetic-ros.yml
+++ b/.github/workflows/noetic-ros.yml
@@ -1,17 +1,22 @@
-name: CI
-
-on: [push, pull_request]
-
+name: CI-noetic
+on:
+  push:
+    branches:
+      - 'noetic'
+  pull_request:
+    branches:
+      - 'noetic'
+  workflow_dispatch:
+    branches:
+      - '*'
 jobs:
   industrial_ci:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: melodic, ROS_REPO: testing}
-          - {ROS_DISTRO: melodic, ROS_REPO: main}
           - {ROS_DISTRO: noetic, ROS_REPO: testing}
           - {ROS_DISTRO: noetic, ROS_REPO: main}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Before: 
ROS CIs checking melodic/noetic compatibility for all branches and always for latest ubuntu.

Now:
Only one CI per ROS distribution. Each CI is assigned to exactly one branch. The additional CI for the main branch must be continuously edited to always match the used ROS distro.