### PR TITLE
Build in ROS1 or 2 with package.xml conditionals

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,7 +40,14 @@ The Las Vegas Surface Reconstruction Toolkit is an Open Source toolkit to recons
   <depend>libopencv-dev</depend>
   <depend>yaml-cpp</depend>
 
+  <!-- ROS1 dependencies -->
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+
+  <!-- ROS2 dependencies -->
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Found these in plotjuggler https://github.com/PlotJuggler/plotjuggler-ros-plugins/blob/main/package.xml - seems to build fine (along with mesh_tools) in my Ubuntu 23.10 catkin workspace, also builds in a ros2 rolling colcon workspace.

If this works in 20.04 noetic also then there's no reason to have a humble branch?