### PR TITLE
Fixes for better ROS integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,15 @@ if(embree_FOUND)
   list(APPEND LVR2_DEFINITIONS -DLVR2_USE_EMBREE)
 endif(embree_FOUND)
 
+
+
 set(CMAKE_MODULE_PATH
-  ${LAS_VEGAS_SOURCE_DIR}/CMakeModules
-  ${LAS_VEGAS_SOURCE_DIR}/ext/kintinuous/cmake/Modules
+  ${PROJECT_SOURCE_DIR}/CMakeModules
+  ${PROJECT_SOURCE_DIR}/ext/kintinuous/cmake/Modules
   ${CMAKE_MODULE_PATH}
 )
+
+message(WARNING "!!!!: ${CMAKE_MODULE_PATH}")
 
 message(STATUS ${CMAKE_MODULE_PATH})
 
@@ -124,6 +128,7 @@ find_package(FLANN REQUIRED)
 if(FLANN_FOUND)
   message(STATUS "Found FLANN")
   include_directories(${FLANN_DIR})
+  message(WARNING "!! FLANN DIR: ${FLANN_DIR}")
 endif(FLANN_FOUND)
 
 find_package(Lz4 REQUIRED)
@@ -458,7 +463,7 @@ endif()
 if(CUDA_FOUND AND "${OpenCV_VERSION_PATCH}" VERSION_GREATER "8" AND WITH_KINFU)
     message(STATUS "Building LVR KinFu.")
     add_subdirectory(ext/kintinuous)
-    include_directories(${LAS_VEGAS_SOURCE_DIR}/ext/kintinuous/kfusion/include)
+    include_directories(${PROJECT_SOURCE_DIR}/ext/kintinuous/kfusion/include)
 endif()
 
 
@@ -717,8 +722,8 @@ if( DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND )
 endif( DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND )
 
 
-find_package(ament_cmake QUIET)
-if(ament_cmake_FOUND)
-  ament_package()
-endif()
+# find_package(ament_cmake QUIET)
+# if(ament_cmake_FOUND)
+#   ament_package()
+# endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4)
-project(LAS_VEGAS VERSION 2)
+project(lvr2 VERSION 2)
 
 # OPTIONS
 option(BUILD_EXAMPLES "Build the examples" OFF)
@@ -15,8 +15,6 @@ set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(GNUInstallDirs)
-
-
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -718,4 +716,9 @@ if( DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND )
       COMMENT "Generating API documentation with Doxygen" VERBATIM )
 endif( DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND )
 
+
+find_package(ament_cmake QUIET)
+if(ament_cmake_FOUND)
+  ament_package()
+endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,11 @@ if(embree_FOUND)
 endif(embree_FOUND)
 
 
-
 set(CMAKE_MODULE_PATH
   ${PROJECT_SOURCE_DIR}/CMakeModules
   ${PROJECT_SOURCE_DIR}/ext/kintinuous/cmake/Modules
   ${CMAKE_MODULE_PATH}
 )
-
-message(WARNING "!!!!: ${CMAKE_MODULE_PATH}")
 
 message(STATUS ${CMAKE_MODULE_PATH})
 
@@ -128,7 +125,6 @@ find_package(FLANN REQUIRED)
 if(FLANN_FOUND)
   message(STATUS "Found FLANN")
   include_directories(${FLANN_DIR})
-  message(WARNING "!! FLANN DIR: ${FLANN_DIR}")
 endif(FLANN_FOUND)
 
 find_package(Lz4 REQUIRED)
@@ -720,10 +716,3 @@ if( DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND )
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
       COMMENT "Generating API documentation with Doxygen" VERBATIM )
 endif( DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND )
-
-
-# find_package(ament_cmake QUIET)
-# if(ament_cmake_FOUND)
-#   ament_package()
-# endif()
-

--- a/package.xml
+++ b/package.xml
@@ -8,9 +8,9 @@ The Las Vegas Surface Reconstruction Toolkit is an Open Source toolkit to recons
 
   <maintainer email="spuetz@uos.de">Sebastian Pütz</maintainer>
   <maintainer email="twiemann@uos.de">Thomas Wiemann</maintainer>
+  <maintainer email="amock@uos.de">Alexander Mock</maintainer>
 
   <license>BSD-3-Clause</license>
-
 
   <url type="website">https://www.las-vegas.uni-osnabrueck.de/</url>
 
@@ -25,6 +25,7 @@ The Las Vegas Surface Reconstruction Toolkit is an Open Source toolkit to recons
   <author email="dofeldsc@uos.de">Dominik Feldschnieders</author>
   <author email="aloehr@uos.de">Alexander Löhr</author>
 
+  <buildtool_depend>cmake</buildtool_depend>
 
   <depend>libflann-dev</depend>
   <depend>libgsl</depend>
@@ -41,6 +42,6 @@ The Las Vegas Surface Reconstruction Toolkit is an Open Source toolkit to recons
   <depend>yaml-cpp</depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
I added cmake as build tool instead of ament_cmake. I think it's better doing it like this since lvr2 is actually a standalone library. It compiles both as standalone cmake package and in a ROS2 - humble repository. I tested it with the mesh_tools.

Other changes:
- matched the cmake project name with the ROS package name (otherwise ROS is complaining)
- Changed some cmake variables to more generic names