### PR TITLE
Missing libtiff-dev dependency to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,7 @@ The Las Vegas Surface Reconstruction Toolkit is an Open Source toolkit to recons
   <depend>lz4</depend>
   <depend>libopencv-dev</depend>
   <depend>yaml-cpp</depend>
+  <depend>libtiff-dev</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Fixes the issue #21 . Tested with ubuntu 20 + ROS noetic. Should be working with ubuntu 22 + ROS humble as well.