### PR TITLE
Add calcNormalClearance algorithm

### DIFF
--- a/include/lvr2/algorithm/GeometryAlgorithms.hpp
+++ b/include/lvr2/algorithm/GeometryAlgorithms.hpp
@@ -35,6 +35,7 @@
 #include "lvr2/geometry/BaseMesh.hpp"
 #include "lvr2/attrmaps/AttrMaps.hpp"
 #include "lvr2/geometry/Handles.hpp"
+#include "lvr2/geometry/Normal.hpp"
 #include <list>
 
 namespace lvr2
@@ -209,6 +210,20 @@ DenseEdgeMap<float> calcVertexDistances(const BaseMesh<BaseVecT>& mesh);
  */
 template<typename BaseVecT>
 DenseVertexMap<float> calcBorderCosts(const BaseMesh<BaseVecT>& mesh, double border_cost = 1.0);
+
+
+/**
+ * @brief Compute the distances to the next intersections along the vertex normals of the mesh
+ *
+ * @param mesh          The mesh containing the geometry of interest
+ * @param normals       The vertex normals used by the algorithm
+ * @return              A dense vertex map containing the free space along the normal of each vertex
+ */
+template <typename BaseVecT>
+DenseVertexMap<float> calcNormalClearance(
+    const BaseMesh<BaseVecT>& mesh,
+    const DenseVertexMap<Normal<typename BaseVecT::CoordType>>& normals
+);
 
 
 /**

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
@@ -58,7 +58,11 @@ public:
     /**
      * @brief Constructor: Stores mesh as member
      */
-    BVHRaycaster(const MeshBufferPtr mesh, unsigned int stack_size = 64);
+    BVHRaycaster(const MeshBufferPtr mesh, unsigned int stack_size);
+    /**
+     * @brief Constructor: Stores mesh as member; Uses BVH depth as stack size
+     */
+    BVHRaycaster(const MeshBufferPtr mesh);
 
     /**
      * @brief Cast a single ray onto the mesh

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
@@ -44,7 +44,6 @@
 #include "Intersection.hpp"
 
 #define EPSILON 0.0000001
-#define PI 3.14159265
 
 namespace lvr2
 {

--- a/include/lvr2/geometry/BVH.hpp
+++ b/include/lvr2/geometry/BVH.hpp
@@ -121,6 +121,11 @@ public:
      */
     const vector<float>& getTrianglesIntersectionData() const;
 
+    /**
+     * @brief Returns the depth of the tree at its deepest node
+     */
+    const uint32_t getMaxDepth() const noexcept;
+
 private:
 
     // Internal triangle representation
@@ -184,6 +189,8 @@ private:
     // working variables for tree construction
     BVHNodePtr m_root;
     vector<Triangle> m_triangles;
+    // Tree depth
+    uint32_t m_depth;
 
     // cache friendly data for the SIMD device
     vector<uint32_t> m_triIndexList;

--- a/include/lvr2/util/Util.hpp
+++ b/include/lvr2/util/Util.hpp
@@ -238,6 +238,24 @@ public:
                    (lhs.x == rhs.x && lhs.y == rhs.y && lhs.z < rhs.z);
         }
     };
+    
+    /**
+    * @brief Convert a BaseVecT to Eigen::Vector3
+    *
+    * @param    vec     The BaseVec to convert to eigen
+    * 
+    * @return Returns the vector as an Eigen::Vector3 object
+    */
+    template <typename BaseVecT>
+    [[nodiscard]]
+    static inline Vector3<typename BaseVecT::CoordType> to_eigen(const BaseVecT& vec) noexcept
+    {
+        return Vector3<typename BaseVecT::CoordType>(
+            vec[0],
+            vec[1],
+            vec[2]
+        );
+    }
 };
 
 } // namespace lvr2


### PR DESCRIPTION
The algorithm computes the free space above the surface at each vertex. It uses the EmbreeRaycaster if embree is available and the BVHRaycaster otherwise. To make the BVHRaycaster work for all mesh sizes a constructor which uses the BVH trees depth to determine the needed stack size is added.

This algorithm is used in the `lvr2_hdf5_mesh_tool` to calculate the `freespace` layer which in turn can be used to prevent the robot from driving through doors, holes, etc. which it would not fit through.