### PR TITLE
fix sign error in BaseVector::rotated

### DIFF
--- a/include/lvr2/geometry/BaseVector.tcc
+++ b/include/lvr2/geometry/BaseVector.tcc
@@ -106,7 +106,7 @@ BaseVector<CoordT> BaseVector<CoordT>::rotated(const BaseVector &n, const double
     return BaseVector(
         (n1sqncos+cos)*x + (n12ncos-n.z*sin)*y + (n13ncos+n.y*sin)*z,
         (n12ncos+n.z*sin)*x + (n2sqncos+cos)*y + (n23ncos-n.x*sin)*z,
-        (n13ncos+n.y*sin)*x + (n23ncos+n.x*sin)*y + (n3sqncos+cos)*z
+        (n13ncos-n.y*sin)*x + (n23ncos+n.x*sin)*y + (n3sqncos+cos)*z
     );
 }
 


### PR DESCRIPTION
The `BaseVector::rotated` function had a plus instead of a minus in the calculation of the rotated vector. The formula for rotating a vector around an arbitrary axis can be looked up here https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle.