### PR TITLE
Fix leaking spdlog symbols in dynamic library

### DIFF
--- a/src/liblvr2/CMakeLists.txt
+++ b/src/liblvr2/CMakeLists.txt
@@ -198,6 +198,7 @@ set(LVR2_INTERNAL_DEPENDENCIES_SHARED
 
 if(UNIX)
   SET_SOURCE_FILES_PROPERTIES(io/BoctreeIO.cpp PROPERTIES COMPILE_FLAGS "-std=c++14")
+  SET_SOURCE_FILES_PROPERTIES(util/Logging.cpp PROPERTIES COMPILE_FLAGS "-fvisibility=hidden")
 endif(UNIX)
 
 
@@ -212,7 +213,7 @@ endif(WITH_3DTILES)
 
 target_link_libraries(lvr2core
     PRIVATE
-    $<BUILD_INTERFACE:spdlog::spdlog>
+    $<BUILD_INTERFACE:spdlog::spdlog_header_only>
     $<BUILD_INTERFACE:spdmon::spdmon>
 )
 
@@ -234,7 +235,7 @@ target_link_libraries(lvr2_static
 )
 target_link_libraries(lvr2_static
     PRIVATE
-    $<BUILD_INTERFACE:spdlog::spdlog>
+    $<BUILD_INTERFACE:spdlog::spdlog_header_only>
     $<BUILD_INTERFACE:spdmon::spdmon>
 )
 target_compile_definitions(lvr2_static
@@ -255,7 +256,7 @@ set_target_properties(lvr2_static
 #####################################################################################
 
 message(STATUS "Building shared library")
-add_library(lvr2 SHARED $<TARGET_OBJECTS:lvr2core>)
+add_library(lvr2 SHARED ${LVR2_SOURCES})
 target_include_directories(lvr2 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/${HIGHFIVE_INCLUDE_DIRS}>
@@ -268,12 +269,13 @@ target_link_libraries(lvr2
 )
 target_link_libraries(lvr2
     PRIVATE
-    $<BUILD_INTERFACE:spdlog::spdlog>
+    $<BUILD_INTERFACE:spdlog::spdlog_header_only>
     $<BUILD_INTERFACE:spdmon::spdmon>
 )
 target_compile_definitions(lvr2 
     PUBLIC
     ${LVR2_DEFINITIONS}
+    -DLVR2_BUILDING_SHARED
 )
 set_target_properties(lvr2
     PROPERTIES
@@ -281,6 +283,7 @@ set_target_properties(lvr2
     SOVERSION ${lvr2_VERSION_MAJOR}
     VERSION ${lvr2_VERSION}
     CXX_STANDARD 17
+    VISIBILITY_INLINES_HIDDEN ON
     INTERFACE_INCLUDE_DIRECTORIES
     ${Boost_INCLUDE_DIRS}
 )

--- a/src/liblvr2/util/Logging.cpp
+++ b/src/liblvr2/util/Logging.cpp
@@ -3,17 +3,25 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdmon/spdmon.hpp>
 
+// This file is compiled with -fvisibility=hidden to prevent spdlog and spdmon symbols
+// to be public in the dynamic library
+#ifdef LVR2_BUILDING_SHARED
+    #define LVR2_API __attribute__ ((visibility ("default")))
+#else
+    #define LVR2_API
+#endif
+
 namespace lvr2
 {
 
-Logger::Logger()
+LVR2_API Logger::Logger()
 {
     m_logger = spdlog::stdout_color_mt("lvr2logger");
     m_logger->set_pattern("[%H:%M:%S:%e]%^[%-7l]%$ %v");
     m_level = LogLevel::info;
 }
 
-void Logger::print()
+LVR2_API void Logger::print()
 {
     spdlog::level::level_enum level;
     
@@ -32,23 +40,23 @@ void Logger::print()
     m_buffer.clear();
 }
 
-void Logger::flush()
+LVR2_API void Logger::flush()
 {
     m_logger->flush();
 }
 
-Monitor::Monitor(const LogLevel& level, const std::string& text, const size_t& max, size_t width)
+LVR2_API Monitor::Monitor(const LogLevel& level, const std::string& text, const size_t& max, size_t width)
 : m_monitor(std::make_shared<spdmon::Progress>(text, max, false, stderr, width))
 , m_prefixText(text)
 {
 }
 
-void Monitor::terminate()
+LVR2_API void Monitor::terminate()
 {
     m_monitor->Terminate();
 }
 
-void Monitor::operator++()
+LVR2_API void Monitor::operator++()
 {
     ++(*m_monitor);
 }


### PR DESCRIPTION
The spdlog functions and definitions were public within the lvr2 shared library which lead to errors when the library is used in a project using a different version of spdlog e.g. ROS2s rclcpp