### PR TITLE
Update the EmbreeRaycaster to use embree4

### DIFF
--- a/.github/workflows/cmake-multi-platform-build.yml
+++ b/.github/workflows/cmake-multi-platform-build.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Set up a matrix to run the following 3 linux versions:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04]
         build_type: [Release]
         c_compiler: [gcc]
         include:
@@ -40,10 +40,6 @@ jobs:
           - os: ubuntu-22.04
             c_compiler: gcc
             cpp_compiler: g++
-          
-          - os: ubuntu-20.04
-            c_compiler: gcc
-            cpp_compiler: g++
 
     steps:
     - uses: actions/checkout@v4
@@ -52,7 +48,7 @@ jobs:
 
     - name: Install dependencies
       run: >
-        sudo apt update && sudo apt install -y libboost-all-dev build-essential cmake cmake-curses-gui libflann-dev libgsl-dev libeigen3-dev libopenmpi-dev openmpi-bin opencl-c-headers ocl-icd-opencl-dev freeglut3-dev libhdf5-dev liblz4-dev libopencv-dev libyaml-cpp-dev libcgal-dev libgdal-dev
+        sudo apt update && sudo apt install -y libboost-all-dev build-essential cmake cmake-curses-gui libflann-dev libgsl-dev libeigen3-dev libopenmpi-dev openmpi-bin opencl-c-headers ocl-icd-opencl-dev freeglut3-dev libhdf5-dev liblz4-dev libopencv-dev libyaml-cpp-dev libcgal-dev libgdal-dev libembree-dev
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 #------------------------------------------------------------------------------
 # Searching for Embree: needs to be placed above "set(CMAKE_MODULE_PATH)".
 #------------------------------------------------------------------------------
-find_package(embree 3.0 QUIET)
+find_package(embree 4.0 QUIET)
 if(embree_FOUND)
   message(STATUS "Found Embree")
   include_directories(${EMBREE_INCLUDE_DIRS})

--- a/LVR2Config.cmake.in
+++ b/LVR2Config.cmake.in
@@ -164,7 +164,7 @@ endif()
 # Embree
 if(@embree_FOUND@)
     set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS ON)
-    find_package(embree 3.0 REQUIRED)
+    find_package(embree 4.0 REQUIRED)
     list(APPEND LVR2_INCLUDE_DIRS ${EMBREE_INCLUDE_DIRS})
     list(APPEND LVR2_LIBRARIES ${EMBREE_LIBRARY})
 endif()

--- a/include/lvr2/algorithm/raycasting/EmbreeRaycaster.hpp
+++ b/include/lvr2/algorithm/raycasting/EmbreeRaycaster.hpp
@@ -35,7 +35,7 @@
 #ifndef LVR2_ALGORITHM_RAYCASTING_EMBREERAYCASTER
 #define LVR2_ALGORITHM_RAYCASTING_EMBREERAYCASTER
 
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 #include <stdio.h>
 
 #include "lvr2/algorithm/raycasting/RaycasterBase.hpp"
@@ -94,7 +94,6 @@ protected:
 
     RTCDevice m_device;
     RTCScene m_scene;
-    RTCIntersectContext m_context;
 };
 
 } // namespace lvr2

--- a/include/lvr2/algorithm/raycasting/EmbreeRaycaster.tcc
+++ b/include/lvr2/algorithm/raycasting/EmbreeRaycaster.tcc
@@ -8,7 +8,6 @@ EmbreeRaycaster<IntT>::EmbreeRaycaster(const MeshBufferPtr mesh)
 {
     m_device = initializeDevice();
     m_scene = initializeScene(m_device, mesh);
-    rtcInitIntersectContext(&m_context);
 }
 
 template<typename IntT>
@@ -25,7 +24,7 @@ bool EmbreeRaycaster<IntT>::castRay(
     IntT& intersection)
 {
     RTCRayHit rayhit = lvr2embree(origin, direction);
-    rtcIntersect1(m_scene, &m_context, &rayhit);
+    rtcIntersect1(m_scene, &rayhit);
     
     if constexpr(IntT::template has<intelem::Point>())
     {

--- a/src/liblvr2/algorithm/raycasting/EmbreeRaycaster.cpp
+++ b/src/liblvr2/algorithm/raycasting/EmbreeRaycaster.cpp
@@ -1,8 +1,6 @@
 #include "lvr2/algorithm/raycasting/EmbreeRaycaster.hpp"
 
-#include <embree3/rtcore.h>
-#include <algorithm>
-#include <iterator>
+#include <embree4/rtcore.h>
 
 namespace lvr2 {
 


### PR DESCRIPTION
This PR updates the EmbreeRaycaster algorithm to use embree4 which was released in February 2023.
It also removes the Ubuntu 20 build because the container is no longer supported by GitHub.