### PR TITLE
Fixing edge cases for sdf marching cubes mesh reconstruction

### DIFF
--- a/include/lvr2/reconstruction/BilinearFastBox.tcc
+++ b/include/lvr2/reconstruction/BilinearFastBox.tcc
@@ -83,8 +83,21 @@ void BilinearFastBox<BaseVecT>::getSurface(
      // cubes table for Paul Burke.
      for(int a = 0; MCTable[index][a] != -1; a+= 3)
      {
-         OptionalVertexHandle vertex_indices[3];
+         // validate that the face will be a visible triangle
+         std::vector<BaseVecT> face_points(3);
+         for(int b = 0; b < 3; b++)
+         {
+             auto edge_index = MCTable[index][a + b];
+             face_points[b] = vertex_positions[edge_index];
+         }
+         if (face_points[0] == face_points[1] ||
+             face_points[0] == face_points[2] ||
+             face_points[2] == face_points[1])
+         {
+             continue;
+         }
 
+         OptionalVertexHandle vertex_indices[3];
          for(int b = 0; b < 3; b++)
          {
              auto edge_index = MCTable[index][a + b];

--- a/include/lvr2/reconstruction/FastBox.tcc
+++ b/include/lvr2/reconstruction/FastBox.tcc
@@ -135,25 +135,24 @@ float FastBox<BaseVecT>::calcIntersection(float x1, float x2, float d1, float d2
 
     // Calculate the surface intersection using linear interpolation
     // and check for different signs of the given distance values.
-    // If for some reason there was no sign change, return the
-    // middle point
-    if ((d1 < 0 && d2 >= 0) || (d2 < 0 && d1 >= 0))
+    // When there is no sign change, just return 0.
+    if (d1 == 0)
+    {
+        return x1;
+    }
+    else if (d2 == 0)
+    {
+        return x2;
+    }
+    else if ((d1 < 0 && d2 > 0) || (d2 < 0 && d1 > 0))
     {
         float interpolation = x2 - d2 * (x1 - x2) / (d1 - d2);
-        if (compareFloat(interpolation, x1))
-        {
-            interpolation += 0.01;
-        }
-        else if (compareFloat(interpolation, x2))
-        {
-            interpolation -= 0.01;
-        }
-
         return interpolation;
     }
     else
     {
-        return (x2 + x1) / 2.0;
+        // no need to waste any compute on this, it wont be used anyways
+        return 0;
     }
 }
 


### PR DESCRIPTION
Normally, it is a very rare occurance to have the signed distance be exactly zero when working with floating points, so this likely never came up as an issue. 

- When working with heavily discretized signed distances that more often evaluate to 0, the current implementation will always place the intersection points between two corners (which is wrong), rather than performing interpolation based on the sd value, in case the signs mismatch or at least one of the signed distances is 0:
https://github.com/uos/lvr2/blob/105a242c818f3cc171235549da66953275059d97/include/lvr2/reconstruction/FastBox.tcc#L132-L158
It also tries to handle edge cases for the interpolation result by simply hardcoding a small offset, which is not a good solution when the chosen voxel size is close to it. When properly handling signed distances of 0, the edge cases within interpolation vanish as well.

- Since a corner with a signed distance of 0 means that a triangle resulting from marching cubes may have 2 or 3 of its vertices on the same corner, invisible faces may be formed that waste both compute and space, while also messing up the face normal calculations. To fix this, a simple check for matching vertices is performed right before any actual vertices/indices are added to the mesh. It doesn't really affect runtime much and there might be prettier solutions, but it works well enough for my case.