### PR TITLE
Fix warnings for users of the library

### DIFF
--- a/include/lvr2/algorithm/ColorAlgorithms.hpp
+++ b/include/lvr2/algorithm/ColorAlgorithms.hpp
@@ -79,7 +79,7 @@ boost::optional<DenseVertexMap<RGB8Color>> calcColorFromPointCloud(
  *
  * @return  The 8-bit RGB-Color, interpreted as rainbowcolor.
  */
-static RGB8Color floatToRainbowColor(float value);
+inline RGB8Color floatToRainbowColor(float value);
 
 /**
  * @brief   Convert a given float to an 8-bit Grayscale-Color.
@@ -92,7 +92,7 @@ static RGB8Color floatToRainbowColor(float value);
  *
  * @return  The 8-bit Grayscale-Color.
  */
-static RGB8Color floatToGrayScaleColor(float value);
+inline RGB8Color floatToGrayScaleColor(float value);
 
 /**
  * @brief    Calculate the color for the centroid of a given face

--- a/include/lvr2/algorithm/ColorAlgorithms.tcc
+++ b/include/lvr2/algorithm/ColorAlgorithms.tcc
@@ -91,7 +91,7 @@ boost::optional<DenseVertexMap<RGB8Color>> calcColorFromPointCloud(
     return vertexMap;
 }
 
-static RGB8Color floatToRainbowColor(float value)
+inline RGB8Color floatToRainbowColor(float value)
 {
     value = std::min(value, 1.0f);
     value = std::max(value, 0.0f);
@@ -135,7 +135,7 @@ static RGB8Color floatToRainbowColor(float value)
     }
 }
 
-static RGB8Color floatToGrayScaleColor(float value)
+inline RGB8Color floatToGrayScaleColor(float value)
 {
     if(value > 1)
     {

--- a/include/lvr2/io/deprecated/hdf5/ChannelIO.tcc
+++ b/include/lvr2/io/deprecated/hdf5/ChannelIO.tcc
@@ -142,6 +142,7 @@ template<typename Derived>
 template <typename T>
 bool ChannelIO<Derived>::getChannel(const std::string group, const std::string name, boost::optional<AttributeChannel<T>>& channel)
 {
+    (void) group;
     // TODO check group for vertex / face attribute and set flag in hdf5 channel
     HighFive::Group g = hdf5util::getGroup(m_file_access->m_hdf5_file, "channels");
     if(m_file_access->m_hdf5_file && m_file_access->m_hdf5_file->isValid())

--- a/include/lvr2/io/deprecated/hdf5/MeshIO.tcc
+++ b/include/lvr2/io/deprecated/hdf5/MeshIO.tcc
@@ -223,7 +223,7 @@ MeshBufferPtr MeshIO<Derived>::load(HighFive::Group& group)
             }
             else
             {
-                for(int i = 0; i < dimensionTextureHandle.at(0); i++)
+                for(long unsigned int i = 0; i < dimensionTextureHandle.at(0); i++)
                 {
                     lvr2::Material nextMat;
                     if(materialColor.get()[i * 3] != -1)

--- a/include/lvr2/io/deprecated/hdf5/PointCloudIO.tcc
+++ b/include/lvr2/io/deprecated/hdf5/PointCloudIO.tcc
@@ -102,6 +102,7 @@ template<typename Derived>
 bool PointCloudIO<Derived>::isPointCloud(
     HighFive::Group& group)
 {
+    (void) group;
     // std::string id(PointCloudIO<Derived>::ID);
     // std::string obj(PointCloudIO<Derived>::OBJID);
     // return hdf5util::checkAttribute(group, "IO", id)
@@ -112,4 +113,4 @@ bool PointCloudIO<Derived>::isPointCloud(
 
 } // hdf5features
 
-} // namespace lvr2 
+} // namespace lvr2

--- a/include/lvr2/util/Hdf5Util.tcc
+++ b/include/lvr2/util/Hdf5Util.tcc
@@ -284,7 +284,10 @@ std::unique_ptr<HighFive::DataSet> createDataset(HighFive::Group& g,
             if (dataset->getDataType() != HighFive::AtomicType<T>())
             {
                 // different datatype -> delete
-                int result = H5Ldelete(g.getId(), datasetName.data(), H5P_DEFAULT);
+                if (0 > H5Ldelete(g.getId(), datasetName.data(), H5P_DEFAULT))
+                {
+                    std::cout << "[Hdf5Util - createDataset] Failed to delete dataset " << datasetName << std::endl;
+                }
                 dataset = std::make_unique<HighFive::DataSet>(
                     g.createDataSet<T>(datasetName, dataSpace, properties));
             }
@@ -326,7 +329,10 @@ std::unique_ptr<HighFive::DataSet> createDataset(HighFive::Group& g,
                         std::cout << "[Hdf5Util - createDataset] WARNING: could not resize. Generating new "
                                     "space..."
                                 << std::endl;
-                        int result = H5Ldelete(g.getId(), datasetName.data(), H5P_DEFAULT);
+                        if (0 > H5Ldelete(g.getId(), datasetName.data(), H5P_DEFAULT))
+                        {
+                            std::cout << "[Hdf5Util - createDataset] Failed to delete dataset " << datasetName << std::endl;
+                        }
 
                         dataset = std::make_unique<HighFive::DataSet>(
                             g.createDataSet<T>(datasetName, dataSpace, properties));
@@ -343,7 +349,8 @@ std::unique_ptr<HighFive::DataSet> createDataset(HighFive::Group& g,
         std::cout << "[Hdf5Util - createDataset] WARNING: could not create dataset ' << " << datasetName << "'. Data Type not allowed by H5" << std::endl;
     }
 
-    return std::move(dataset);
+    // using std::move() on dataset in this return prevents the compiler from optimizing away the copy (copy elision)
+    return dataset;
 }
 
 template <typename T, typename HT>

--- a/include/lvr2/util/Logging.hpp
+++ b/include/lvr2/util/Logging.hpp
@@ -154,22 +154,22 @@ struct LoggerInfo{};
 struct LoggerDebug{};
 
 /// @brief Endline and flush for logger objects
-static LoggerEndline endl;
+inline constexpr LoggerEndline endl;
 
 /// @brief Marks error log level for streamed output
-static LoggerError error;
+inline constexpr LoggerError error;
 
 /// @brief Marks warning log level for streamed output
-static LoggerWarning warning;
+inline constexpr LoggerWarning warning;
 
 /// @brief Marks trace log level for streamed output
-static LoggerTrace trace;
+inline constexpr LoggerTrace trace;
 
 /// @brief Marks info log level for streamed output
-static LoggerInfo info;
+inline constexpr LoggerInfo info;
 
 /// @brief Marks debug log level for streamed output
-static LoggerDebug debug;
+inline constexpr LoggerDebug debug;
 
 // Alias for logger singleton
 using logout = Logger;


### PR DESCRIPTION
This PR fixes a bunch of compiler warnings that occur when using the LVR2 library in other projects.
Most of these were related to unused variables and functions in header files.