### PR TITLE
Remove Boost.System and search for upstream boost configuration file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,6 @@ set(Boost_USE_MULTITHREADED     ON)
 set(Boost_COMPONENTS
   program_options
   filesystem
-  system
   thread
   serialization
   timer
@@ -203,7 +202,7 @@ if(MPI_FOUND)
   message(STATUS "Found MPI. Adding Boost MPI library to required components.")
 endif()
 
-find_package(Boost COMPONENTS ${Boost_COMPONENTS} REQUIRED QUIET)
+find_package(Boost COMPONENTS ${Boost_COMPONENTS} CONFIG REQUIRED QUIET)
 message(STATUS "Found Boost libraries")
 
 link_directories(${Boost_LIBRARY_DIR})


### PR DESCRIPTION
`Boost.System` is not being used (and isn't packaged everywhere, so may lead to unnecessary issues).
The [FindBoost](https://cmake.org/cmake/help/latest/module/FindBoost.html#module:FindBoost) CMake module is also deprecated and using the `CONFIG` mode should be preferred as per [CMP0167](https://cmake.org/cmake/help/latest/policy/CMP0167.html).