### PR TITLE
Add Homebrew prefix to CMAKE_PREFIX_PATH for lvr2 package

### DIFF
--- a/CMakeModules/lvr2-config.cmake.in
+++ b/CMakeModules/lvr2-config.cmake.in
@@ -46,6 +46,11 @@ find_dependency(TBB)
 if(@MPI_FOUND@)
   find_dependency(MPI)
 endif()
+
+# Without adding the prefix to the prefix list here downstream packages cannot find OpenMP properly
+if(EXISTS @HOMEBREW_LIBOMP_PREFIX@)
+  list(APPEND CMAKE_PREFIX_PATH @HOMEBREW_LIBOMP_PREFIX@)
+endif()
 find_dependency(OpenMP)
 find_dependency(TIFF)
 find_dependency(GDAL)


### PR DESCRIPTION
This fixes build of downstream packages on macos.

* [`CMakeModules/lvr2-config.cmake.in`](diffhunk://#diff-9dc43024a31e83e24d2ad11f505ddbf4a6871f86a143139b20dc6ae6490eceddR49-R53): Appends the Homebrew `libomp` prefix to the `CMAKE_PREFIX_PATH` if it was used during build, which enables downstream packages to properly locate and link against OpenMP.