### PR TITLE
Make GDAL dependency optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(LVR2_WITH_OPENCL "Compile with OpenCL support, if available" ON)
 option(LVR2_WITH_PCL "Compile with PCL support" OFF)
 option(LVR2_WITH_FREENECT "Compile with libfreenect grabber" OFF)
 option(LVR2_WITH_CV_NONFREE "Use OpenCV non-free descriptors" OFF)
+option(LVR2_WITH_GDAL "Compile with GDAL integrations (GeoTIFFIO)" OFF)
 
 ## Compile as C++17
 set(CMAKE_CXX_STANDARD 17)
@@ -145,8 +146,11 @@ include_directories(${TIFF_INCLUDE_DIRS})
 #------------------------------------------------------------------------------
 # Searching for GDAL
 #------------------------------------------------------------------------------
-find_package(GDAL REQUIRED)
-include_directories(${GDAL_INCLUDE_DIR})
+if (LVR2_WITH_GDAL)
+  find_package(GDAL REQUIRED)
+  include_directories(${GDAL_INCLUDE_DIR})
+  list(APPEND LVR2_DEFINITIONS -DLVR2_USE_GDAL)
+endif (LVR2_WITH_GDAL)
 
 #------------------------------------------------------------------------------
 # Searching for OpenCV
@@ -673,7 +677,6 @@ set(LVR2_LIB_DEPENDENCIES
     ${Boost_IOSTREAMS_LIBRARY}
     ${OPENGL_LIBRARIES}
     ${GLUT_LIBRARIES}
-    ${GDAL_LIBRARY}
     ${OpenCV_LIBS}
     ${GSL_LIBRARIES}
     ${LZ4_LIBRARY}
@@ -694,7 +697,6 @@ set(LVR2_LIB_DEPENDENCIES
     ${Boost_IOSTREAMS_LIBRARY}
     ${OPENGL_LIBRARIES}
     ${GLUT_LIBRARIES}
-    ${GDAL_LIBRARY}
     ${OpenCV_LIBS}
     ${GSL_LIBRARIES}
     ${LZ4_LIBRARY}
@@ -755,6 +757,10 @@ endif(embree_FOUND)
 if(3DTILES_FOUND)
   list(APPEND LVR2_LIB_DEPENDENCIES ${3DTILES_LIBRARIES})
 endif(3DTILES_FOUND)
+
+if(GDAL_FOUND)
+  list(APPEND LVR2_LIB_DEPENDENCIES ${GDAL_LIBRARY})
+endif(GDAL_FOUND)
 
 ###############################################################################
 # LIBRARIES

--- a/CMakeModules/lvr2-config.cmake.in
+++ b/CMakeModules/lvr2-config.cmake.in
@@ -53,7 +53,6 @@ if(EXISTS @HOMEBREW_LIBOMP_PREFIX@)
 endif()
 find_dependency(OpenMP)
 find_dependency(TIFF)
-find_dependency(GDAL)
 find_dependency(OpenCV)
 
 find_dependency(FLANN)
@@ -102,6 +101,11 @@ endif()
 if(@embree_FOUND@)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS ON)
   find_package(embree @LVR2_EMBREE_VERSION@ REQUIRED)
+endif()
+
+# GDAL
+if(@GDAL_FOUND@)
+    find_package(GDAL REQUIRED)
 endif()
 
 set(lvr2_FOUND TRUE)

--- a/CMakeModules/lvr2-packaging.cmake
+++ b/CMakeModules/lvr2-packaging.cmake
@@ -44,7 +44,6 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(_LVR2_DEPS
     libeigen3-dev
     libflann-dev
-    libgdal-dev
     libglut-dev
     libgsl-dev
     libhdf5-dev
@@ -74,6 +73,11 @@ endforeach()
 # Depend on embree if it was used during build
 if(embree_FOUND)
     list(APPEND _LVR2_DEPS "libembree-dev")
+endif()
+
+# Depend on gdal if it was used during build
+if(GDAL_FOUND)
+    list(APPEND _LVR2_DEPS "libgdal-dev")
 endif()
 
 # Convert list → comma-separated string

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cmake .. && make
 Install the required libraries using [Homebrew](https://brew.sh):
 
 ```bash
-brew install boost boost-mpi cmake eigen flann gcc gdal glew gsl hdf5 opencv libtiff lz4 qt vtk yaml-cpp
+brew install boost boost-mpi cmake eigen flann gcc glew gsl hdf5 opencv libtiff lz4 qt vtk yaml-cpp
 
 mkdir build
 cd build

--- a/include/lvr2/io/modelio/GeoTIFFIO.hpp
+++ b/include/lvr2/io/modelio/GeoTIFFIO.hpp
@@ -26,6 +26,7 @@
  */
 #ifndef GEOTIFFIO_HPP
 #define GEOTIFFIO_HPP
+#ifdef LVR2_USE_GDAL
 
 #include <opencv2/opencv.hpp>
 #include <string>
@@ -118,6 +119,7 @@ private:
     int m_cols, m_rows, m_bands;
 };
 }
-
-
+#else
+#error "LVR2 was build without the GDAL integration. Configure cmake with -DLVR2_WITH_GDAL to enable GeoTIFFIO"
+#endif // LVR2_USE_GDAL
 #endif //GEOTIFFIO_HPP

--- a/package.xml
+++ b/package.xml
@@ -35,7 +35,6 @@ point clouds.
 
   <depend>tbb</depend>
   <depend>libtiff-dev</depend>
-  <depend>libgdal-dev</depend>
   <depend>libopencv-dev</depend>
   <depend>libflann-dev</depend>
   <depend>lz4</depend>

--- a/src/liblvr2/CMakeLists.txt
+++ b/src/liblvr2/CMakeLists.txt
@@ -48,7 +48,6 @@ set(LVR2_SOURCES
     io/modelio/ObjIO.cpp
     io/modelio/DatIO.cpp
     io/modelio/LasIO.cpp
-    io/modelio/GeoTIFFIO.cpp
     # io/KinectIO.cpp
     io/AttributeMeshIOBase.cpp
     io/modelio/PPMIO.cpp
@@ -177,6 +176,14 @@ if(OPENCL_FOUND)
     list(APPEND LVR2_SOURCES
         reconstruction/opencl/ClSurface.cpp
         reconstruction/opencl/ClStatisticalOutlierFilter.cpp)
+endif()
+
+#####################################################################################
+# GDAL
+#####################################################################################
+
+if(LVR2_WITH_GDAL)
+    list(APPEND LVR2_SOURCES io/modelio/GeoTIFFIO.cpp)
 endif()
 
 #####################################################################################


### PR DESCRIPTION
This removes a huge chunk of the dependency tree at the cost of making the GeoTIFFIO feature optional. We could, in the future, rewrite the GeoTIFFIO to use libgeotiff directly but since there are no tests for the integration at the moment no rewrite was tried.