### PR TITLE
Add new IClosestSurfacePointQuery Interface

### DIFF
--- a/.github/workflows/cmake-multi-platform-build.yml
+++ b/.github/workflows/cmake-multi-platform-build.yml
@@ -65,8 +65,13 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DLVR2_BUILD_TESTING=ON
         -S ${{ github.workspace }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Test
+      # Run all tests using ctest
+      run: cd ${{ steps.strings.outputs.build-output-dir }} && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(LVR2_BUILD_EXAMPLES "Build the examples" OFF)
 option(LVR2_BUILD_VIEWER "Build lvr2_viewer" OFF)
 option(LVR2_BUILD_TOOLS "Build tools including lvr2_reconstruct" ON)
 option(LVR2_BUILD_TOOLS_EXPERIMENTAL "Build experimental tools" OFF)
+option(LVR2_BUILD_TESTING "Build the tests" OFF)
 option(LVR2_WITH_KINFU "Compile LVR Kinfu" OFF)
 option(LVR2_WITH_3DTILES "Compile with 3DTiles support" OFF)
 option(LVR2_WITH_CUDA "Compile with CUDA support, if available" ON)
@@ -860,6 +861,14 @@ if(LVR2_BUILD_VIEWER)
     add_subdirectory(src/tools/lvr2_ascii_viewer)
   endif()
 endif(LVR2_BUILD_VIEWER)
+
+###############################################################################
+# TESTS
+###############################################################################
+if (LVR2_BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(src/tests)
+endif()
 
 ###############################################################################
 # CMAKE FILES

--- a/include/lvr2/algorithm/ClosestSurfacePoint.hpp
+++ b/include/lvr2/algorithm/ClosestSurfacePoint.hpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026, University Osnabrück
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the University Osnabrück nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL University Osnabrück BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "lvr2/geometry/Handles.hpp"
+#include "lvr2/types/MatrixTypes.hpp"
+#include <optional>
+namespace lvr2 {
+
+/**
+ *  @brief Result of a closest surface point query.
+ */
+struct ClosestSurfacePointQueryResult {
+    Vector3f point;
+    lvr2::FaceHandle face;
+};
+
+/**
+ *  @brief Search the closest point on a mesh surface to a query point.
+ */
+class IClosestSurfacePointQuery {
+public:
+
+    /**
+     *  @brief Search for the closest point on the mesh's surface.
+     *
+     *  @param query The position to find the closest surface point for
+     *  @return The closest surface point if one exists; nullopt otherwise
+     */
+    virtual std::optional<ClosestSurfacePointQueryResult> getClosestPoint(const Vector3f& query) const = 0;
+};
+
+} // namespace lvr2

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
@@ -40,6 +40,7 @@
 #include "lvr2/types/MeshBuffer.hpp"
 #include "lvr2/types/MatrixTypes.hpp"
 #include "lvr2/geometry/BVH.hpp"
+#include "lvr2/algorithm/ClosestSurfacePoint.hpp"
 #include "lvr2/algorithm/raycasting/RaycasterBase.hpp"
 #include "Intersection.hpp"
 
@@ -50,7 +51,10 @@ namespace lvr2
  *  @brief BVHRaycaster: CPU version of BVH Raycasting: WIP
  */
 template<typename IntT>
-class BVHRaycaster : public RaycasterBase<IntT> {
+class BVHRaycaster
+: public RaycasterBase<IntT>
+, public IClosestSurfacePointQuery
+{
 public:
     /**
      * @brief Constructor: Stores mesh as member

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
@@ -31,6 +31,7 @@
  *  @date 25.01.2019
  *  @author Johan M. von Behren <johan@vonbehren.eu>
  *  @author Alexander Mock <amock@uos.de>
+ *  @author Justus Braun <jubraun@uos.de>
  */
 
 #pragma once
@@ -48,7 +49,7 @@ namespace lvr2
 {
 
 /**
- *  @brief BVHRaycaster: CPU version of BVH Raycasting: WIP
+ *  @brief BVHRaycaster: CPU version of BVH Raycasting and BVH closest point query
  */
 template<typename IntT>
 class BVHRaycaster

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.hpp
@@ -64,6 +64,14 @@ public:
     BVHRaycaster(const MeshBufferPtr mesh);
 
     /**
+     *  @brief Search for the closest point on the mesh's surface.
+     *
+     *  @param query The position to find the closest surface point for
+     *  @return The closest surface point if one exists; nullopt otherwise
+     */
+    std::optional<ClosestSurfacePointQueryResult> getClosestPoint(const Vector3f& query) const;
+
+    /**
      * @brief Cast a single ray onto the mesh
      * 
      * @param[in] origin Ray origin 
@@ -179,6 +187,14 @@ private:
         const float* clTriangleIntersectionData,
         const unsigned int* clTriIdxList
     );
+
+    /**
+     * @brief Computes the squared distance of p to the cache friendly aabb
+     *
+     * @param aabb Pointer to the aabb data
+     * @param point the query point
+     */
+    float squaredDistanceToAABB(const float* aabb, const Vector3f& point) const;
 
 };
 

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
@@ -21,6 +21,7 @@ std::optional<ClosestSurfacePointQueryResult> BVHRaycaster<IntT>::getClosestPoin
     float bestDistSq = std::numeric_limits<float>::infinity();
 
     std::stack<unsigned int> stack;
+    // Push the root node to initialize search loop
     stack.push(0);
 
     while (!stack.empty())
@@ -63,6 +64,7 @@ std::optional<ClosestSurfacePointQueryResult> BVHRaycaster<IntT>::getClosestPoin
                 pmp::Point pmpV2(m_vertices[v2 * 3 + 0], m_vertices[v2 * 3 + 1], m_vertices[v2 * 3 + 2]);
 
                 pmp::Point nearestPoint;
+                // Compute squared distance for comparison
                 const float dist_sq = std::pow(pmp::dist_point_triangle(pmpQuery, pmpV0, pmpV1, pmpV2, nearestPoint), 2);
 
                 if (dist_sq < bestDistSq)

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
@@ -1,7 +1,97 @@
 
+#include "lvr2/types/MatrixTypes.hpp"
+#include <limits>
 #define EPSILON 0.0000001
 
+#include "lvr2/algorithm/pmp/DistancePointTriangle.h"
+
 namespace lvr2 {
+
+template<typename IntT>
+std::optional<ClosestSurfacePointQueryResult> BVHRaycaster<IntT>::getClosestPoint(const Vector3f& query) const
+{
+    if (m_faces.get() == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    unsigned int pBestTriId = 0;
+    Vector3f pBestPoint = query;
+    float bestDistSq = std::numeric_limits<float>::infinity();
+
+    std::stack<unsigned int> stack;
+    stack.push(0);
+
+    while (!stack.empty())
+    {
+        unsigned int boxId = stack.top();
+        stack.pop();
+
+        if (!(m_BVHindicesOrTriLists[4 * boxId + 0] & 0x80000000)) // inner node
+        {
+            const float* limitsMin = &m_BVHlimits[6 * boxId];
+
+            // Compute squared distance from query to AABB
+            float d2 = this->squaredDistanceToAABB(limitsMin, query);
+
+            if (d2 > bestDistSq)
+            {
+                continue; // prune this subtree
+            }
+
+            stack.push(m_BVHindicesOrTriLists[4 * boxId + 1]);
+            stack.push(m_BVHindicesOrTriLists[4 * boxId + 2]);
+        }
+        else // leaf node
+        {
+            unsigned int triCount = m_BVHindicesOrTriLists[4 * boxId + 0] & 0x7fffffff;
+            unsigned int startIdx = m_BVHindicesOrTriLists[4 * boxId + 3];
+
+            // Check all triangles of this leaf
+            for (unsigned int i = startIdx; i < startIdx + triCount; i++)
+            {
+                unsigned int idx = m_TriIdxList[i];
+
+                unsigned int v0 = m_faces[idx * 3 + 0];
+                unsigned int v1 = m_faces[idx * 3 + 1];
+                unsigned int v2 = m_faces[idx * 3 + 2];
+
+                pmp::Point pmpQuery(query.x(), query.y(), query.z());
+                pmp::Point pmpV0(m_vertices[v0 * 3 + 0], m_vertices[v0 * 3 + 1], m_vertices[v0 * 3 + 2]);
+                pmp::Point pmpV1(m_vertices[v1 * 3 + 0], m_vertices[v1 * 3 + 1], m_vertices[v1 * 3 + 2]);
+                pmp::Point pmpV2(m_vertices[v2 * 3 + 0], m_vertices[v2 * 3 + 1], m_vertices[v2 * 3 + 2]);
+
+                pmp::Point nearestPoint;
+                const float dist_sq = std::pow(pmp::dist_point_triangle(pmpQuery, pmpV0, pmpV1, pmpV2, nearestPoint), 2);
+
+                if (dist_sq < bestDistSq)
+                {
+                    bestDistSq = dist_sq;
+                    pBestPoint = Vector3f(nearestPoint.x(), nearestPoint.y(), nearestPoint.z());
+                    pBestTriId = idx;
+                }
+            }
+        }
+    }
+
+    ClosestSurfacePointQueryResult result;
+    result.point = pBestPoint;
+    result.face = FaceHandle(pBestTriId);
+    return result;
+}
+
+template<typename IntT>
+float BVHRaycaster<IntT>::squaredDistanceToAABB(const float* aabb, const Vector3f& point) const {
+    /* AABB layout is min x, max x, min y, max y, min z, max z */
+    // Closest point on aabb surface is the query point clamped along the axis
+    const Vector3f cp(
+        std::clamp(point.x(), aabb[0], aabb[1]),
+        std::clamp(point.y(), aabb[2], aabb[3]),
+        std::clamp(point.z(), aabb[4], aabb[5])
+    );
+
+    return (cp - point).squaredNorm();
+}
 
 template<typename IntT>
 BVHRaycaster<IntT>::BVHRaycaster(const MeshBufferPtr mesh, unsigned int stack_size)

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
@@ -5,8 +5,7 @@ namespace lvr2 {
 
 template<typename IntT>
 BVHRaycaster<IntT>::BVHRaycaster(const MeshBufferPtr mesh, unsigned int stack_size)
-:RaycasterBase<IntT>(mesh)
-,m_bvh(mesh)
+:m_bvh(mesh)
 ,m_faces(mesh->getFaceIndices())
 ,m_vertices(mesh->getVertices())
 ,m_BVHindicesOrTriLists(m_bvh.getIndexesOrTrilists().data())
@@ -20,8 +19,7 @@ BVHRaycaster<IntT>::BVHRaycaster(const MeshBufferPtr mesh, unsigned int stack_si
 
 template<typename IntT>
 BVHRaycaster<IntT>::BVHRaycaster(const MeshBufferPtr mesh)
-:RaycasterBase<IntT>(mesh)
-,m_bvh(mesh)
+:m_bvh(mesh)
 ,m_faces(mesh->getFaceIndices())
 ,m_vertices(mesh->getVertices())
 ,m_BVHindicesOrTriLists(m_bvh.getIndexesOrTrilists().data())

--- a/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
+++ b/include/lvr2/algorithm/raycasting/BVHRaycaster.tcc
@@ -1,6 +1,7 @@
 
 #include "lvr2/types/MatrixTypes.hpp"
 #include <limits>
+#include <stack>
 #define EPSILON 0.0000001
 
 #include "lvr2/algorithm/pmp/DistancePointTriangle.h"

--- a/include/lvr2/algorithm/raycasting/EmbreeRaycaster.hpp
+++ b/include/lvr2/algorithm/raycasting/EmbreeRaycaster.hpp
@@ -49,13 +49,26 @@
 #include "lvr2/types/MeshBuffer.hpp"
 #include "lvr2/types/MatrixTypes.hpp"
 #include "Intersection.hpp"
+#include "lvr2/algorithm/ClosestSurfacePoint.hpp"
 
 namespace lvr2 {
 
 void EmbreeErrorFunction(void* userPtr, enum RTCError error, const char* str);
 
+struct EmbreeClosestPointState {
+    const float*         vertices;
+    const unsigned int*  faces;
+    ClosestSurfacePointQueryResult result;
+    bool                 found;
+};
+
+bool embreeClosestPointCallback(RTCPointQueryFunctionArguments* args);
+
 template<typename IntT>
-class EmbreeRaycaster : public RaycasterBase<IntT> {
+class EmbreeRaycaster
+: public RaycasterBase<IntT>
+, public IClosestSurfacePointQuery
+{
 public:
     EmbreeRaycaster(const MeshBufferPtr mesh);
     ~EmbreeRaycaster();
@@ -73,6 +86,14 @@ public:
         const Vector3f& origin,
         const Vector3f& direction,
         IntT& intersection);
+
+    /**
+     *  @brief Search for the closest point on the mesh's surface.
+     *
+     *  @param query The position to find the closest surface point for
+     *  @return The closest surface point if one exists; nullopt otherwise
+     */
+    std::optional<ClosestSurfacePointQueryResult> getClosestPoint(const Vector3f& query) const;
 
 protected:
 
@@ -99,6 +120,7 @@ protected:
         return rayhit;
     }
 
+    MeshBufferPtr m_mesh;
     RTCDevice m_device;
     RTCScene m_scene;
 

--- a/include/lvr2/algorithm/raycasting/EmbreeRaycaster.tcc
+++ b/include/lvr2/algorithm/raycasting/EmbreeRaycaster.tcc
@@ -4,7 +4,7 @@ namespace lvr2 {
 
 template<typename IntT>
 EmbreeRaycaster<IntT>::EmbreeRaycaster(const MeshBufferPtr mesh)
-:RaycasterBase<IntT>(mesh)
+: m_mesh(mesh)
 {
     m_device = initializeDevice();
     m_scene = initializeScene(m_device, mesh);
@@ -76,6 +76,38 @@ bool EmbreeRaycaster<IntT>::castRay(
     }
 
     return (rayhit.hit.geomID != RTC_INVALID_GEOMETRY_ID);
+}
+
+template<typename IntT>
+std::optional<ClosestSurfacePointQueryResult>
+EmbreeRaycaster<IntT>::getClosestPoint(const Vector3f& query) const
+{
+    if (!m_mesh || !m_mesh->hasFaces())
+        return std::nullopt;
+
+    RTCPointQuery rtcQuery;
+    rtcQuery.x      = query.x();
+    rtcQuery.y      = query.y();
+    rtcQuery.z      = query.z();
+    rtcQuery.time   = 0.0f;
+    rtcQuery.radius = std::numeric_limits<float>::infinity();
+
+    RTCPointQueryContext context;
+    rtcInitPointQueryContext(&context);
+
+    auto vertices = m_mesh->getVertices();
+    auto faces    = m_mesh->getFaceIndices();
+
+    EmbreeClosestPointState state;
+    state.vertices = vertices.get();
+    state.faces    = faces.get();
+    state.found    = false;
+
+    rtcPointQuery(m_scene, &rtcQuery, &context, embreeClosestPointCallback, &state);
+
+    if (state.found)
+        return state.result;
+    return std::nullopt;
 }
 
 // PRIVATE

--- a/include/lvr2/algorithm/raycasting/RaycasterBase.hpp
+++ b/include/lvr2/algorithm/raycasting/RaycasterBase.hpp
@@ -52,10 +52,6 @@ namespace lvr2
 template<typename IntT>
 class RaycasterBase {
 public:
-    /**
-     * @brief Constructor: Stores mesh as member
-     */
-    RaycasterBase(const MeshBufferPtr mesh);
 
     // PURE VIRTUALS
     /**
@@ -138,9 +134,6 @@ public:
         std::vector<std::vector<IntT> >& intersections,
         std::vector<std::vector<uint8_t> >& hits
     );
-
-private:
-    const MeshBufferPtr m_mesh;
 };
 
 template<typename IntT>

--- a/include/lvr2/algorithm/raycasting/RaycasterBase.tcc
+++ b/include/lvr2/algorithm/raycasting/RaycasterBase.tcc
@@ -2,13 +2,6 @@ namespace lvr2
 {
 
 template<typename IntT>
-RaycasterBase<IntT>::RaycasterBase(const MeshBufferPtr mesh)
-:m_mesh(mesh)
-{
-
-}
-
-template<typename IntT>
 void RaycasterBase<IntT>::castRays(
     const Vector3f& origin,
     const std::vector<Vector3f>& directions,

--- a/include/lvr2/attrmaps/StableVector.tcc
+++ b/include/lvr2/attrmaps/StableVector.tcc
@@ -92,7 +92,7 @@ HandleT StableVector<HandleT, ElemT>::push(const ElementType& elem)
 template<typename HandleT, typename ElemT>
 HandleT StableVector<HandleT, ElemT>::push(ElementType&& elem)
 {
-    m_elements.emplace_back(move(elem));
+    m_elements.emplace_back(std::move(elem));
     ++m_usedCount;
     return HandleT(size() - 1);
 }

--- a/include/lvr2/geometry/BVH.hpp
+++ b/include/lvr2/geometry/BVH.hpp
@@ -162,6 +162,7 @@ private:
     struct BVHNode {
         BoundingBox<BaseVecT> bb;
         virtual bool isLeaf() = 0;
+        virtual ~BVHNode() = default;
     };
     using BVHNodePtr = unique_ptr<BVHNode>;
 

--- a/include/lvr2/geometry/BVH.tcc
+++ b/include/lvr2/geometry/BVH.tcc
@@ -323,7 +323,7 @@ typename BVHTree<BaseVecT>::BVHNodePtr BVHTree<BaseVecT>::buildTreeRecursive(vec
         {
             m_depth = std::max(m_depth, depth);
         }
-        return move(leaf);
+        return std::move(leaf);
     }
 
     // divide node into smaller nodes
@@ -447,7 +447,7 @@ typename BVHTree<BaseVecT>::BVHNodePtr BVHTree<BaseVecT>::buildTreeRecursive(vec
         {
             m_depth = std::max(m_depth, depth);
         }
-        return move(leaf);
+        return std::move(leaf);
     }
 
     vector<AABB> leftWork;
@@ -508,7 +508,7 @@ typename BVHTree<BaseVecT>::BVHNodePtr BVHTree<BaseVecT>::buildTreeRecursive(vec
     #pragma omp taskwait
     // }
     
-    return move(inner);
+    return std::move(inner);
 }
 
 template<typename BaseVecT>
@@ -516,7 +516,7 @@ void BVHTree<BaseVecT>::createCFTree()
 {
     m_triIndexList.reserve(m_triangles.size());
     uint32_t idxBoxes = 0;
-    createCFTreeRecursive(move(m_root), idxBoxes);
+    createCFTreeRecursive(std::move(m_root), idxBoxes);
     convertTrianglesIntersectionData();
 }
 
@@ -551,9 +551,9 @@ void BVHTree<BaseVecT>::createCFTreeRecursive(BVHNodePtr currentNode, uint32_t& 
 
         // now recurse
         uint32_t idxLeft = ++idxBoxes;
-        createCFTreeRecursive(move(inner->left), idxBoxes);
+        createCFTreeRecursive(std::move(inner->left), idxBoxes);
         uint32_t idxRight = ++idxBoxes;
-        createCFTreeRecursive(move(inner->right), idxBoxes);
+        createCFTreeRecursive(std::move(inner->right), idxBoxes);
 
         // fix box indices
         m_indexesOrTrilists[indexesOrTrilistsPos] = idxLeft;

--- a/include/lvr2/geometry/BaseVector.hpp
+++ b/include/lvr2/geometry/BaseVector.hpp
@@ -221,6 +221,12 @@ public:
     template<typename T, typename S>
     friend BaseVector<T> operator*(const Eigen::Matrix<S, 4, 4>& mat, const BaseVector<T>& normal);
 
+    // Copy Constructor from Eigen Vector (lvr2::Vector3)
+    constexpr BaseVector(const Eigen::Vector3<CoordT>& vec);
+
+    // Conversion to Eigen::Vector3
+    constexpr operator Eigen::Vector3<CoordT>() const;
+
 #endif // ifndef __NVCC__
 
 };

--- a/include/lvr2/geometry/BaseVector.tcc
+++ b/include/lvr2/geometry/BaseVector.tcc
@@ -231,6 +231,23 @@ CoordT& BaseVector<CoordT>::operator[](const unsigned& index)
     }
 }
 
+// Eigen sometimes produces errors when compiled with CUDA. Disables
+// all Eigen related function for CUDA code (which is currently fine).
+#ifndef __NVCC__
+template<typename CoordT>
+constexpr BaseVector<CoordT>::BaseVector(const Eigen::Vector3<CoordT>& rhs)
+: x(rhs.x())
+, y(rhs.y())
+, z(rhs.z())
+{}
+
+template<typename CoordT>
+constexpr BaseVector<CoordT>::operator Eigen::Vector3<CoordT>() const
+{
+    return Eigen::Vector3<CoordT>(this->x, this->y, this->z);
+}
+#endif // ifndef __NVCC__
+
 template <typename CoordT>
 Normal<CoordT> BaseVector<CoordT>::normalized() const
 {

--- a/include/lvr2/types/ElementProxy.hpp
+++ b/include/lvr2/types/ElementProxy.hpp
@@ -34,6 +34,7 @@
 #include <boost/optional.hpp>
 #include <memory>
 #include "lvr2/geometry/Handles.hpp"
+#include "lvr2/geometry/BaseVector.hpp"
 
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
@@ -244,15 +245,24 @@ public:
         throw std::range_error("Element Proxy: Index out of Bounds");
     }
 
-    /// User defined conversion operator
-    template<typename BaseVecT>
-    operator BaseVecT() const
+    // Conversion to BaseVector
+    operator lvr2::BaseVector<T>() const
     {
         if(m_w == 3)
         {
-            return BaseVecT(m_ptr[0], m_ptr[1], m_ptr[2]);
+            return lvr2::BaseVector<T>(m_ptr[0], m_ptr[1], m_ptr[2]);
         }
-        throw std::range_error("Element Proxy: Width != 3 in BaseVecT conversion");
+        throw std::range_error("Element Proxy: Width != 3 in BaseVector<T> conversion");
+    }
+
+    // Conversion to Normal
+    operator lvr2::Normal<T>() const
+    {
+        if(m_w == 3)
+        {
+            return lvr2::Normal<T>(m_ptr[0], m_ptr[1], m_ptr[2]);
+        }
+        throw std::range_error("Element Proxy: Width != 3 in BaseVector<T> conversion");
     }
 
     template <typename type, size_t size>

--- a/src/liblvr2/algorithm/raycasting/EmbreeRaycaster.cpp
+++ b/src/liblvr2/algorithm/raycasting/EmbreeRaycaster.cpp
@@ -1,4 +1,5 @@
 #include "lvr2/algorithm/raycasting/EmbreeRaycaster.hpp"
+#include "lvr2/algorithm/pmp/DistancePointTriangle.h"
 
 #if LVR2_EMBREE_VERSION == 3
 #include <embree3/rtcore.h>
@@ -11,6 +12,31 @@ namespace lvr2 {
 void EmbreeErrorFunction(void* userPtr, enum RTCError error, const char* str)
 {
     printf("error %d: %s\n", error, str);
+}
+
+bool embreeClosestPointCallback(RTCPointQueryFunctionArguments* args)
+{
+    auto* state = static_cast<EmbreeClosestPointState*>(args->userPtr);
+    const unsigned int primID = args->primID;
+    const unsigned int* f = state->faces + primID * 3;
+    const float* v = state->vertices;
+
+    pmp::Point a(v[f[0]*3+0], v[f[0]*3+1], v[f[0]*3+2]);
+    pmp::Point b(v[f[1]*3+0], v[f[1]*3+1], v[f[1]*3+2]);
+    pmp::Point c(v[f[2]*3+0], v[f[2]*3+1], v[f[2]*3+2]);
+    pmp::Point q(args->query->x, args->query->y, args->query->z);
+
+    pmp::Point nearest_point;
+    pmp::Scalar d = pmp::dist_point_triangle(q, a, b, c, nearest_point);
+
+    if (d < args->query->radius) {
+        args->query->radius = static_cast<float>(d);
+        state->result.point = nearest_point.cast<float>();
+        state->result.face  = FaceHandle(primID);
+        state->found = true;
+        return true;
+    }
+    return false;
 }
 
 } // namespace lvr2

--- a/src/liblvr2/io/modelio/GeoTIFFIO.cpp
+++ b/src/liblvr2/io/modelio/GeoTIFFIO.cpp
@@ -7,7 +7,7 @@
 #include "lvr2/io/modelio/GeoTIFFIO.hpp"
 #include "lvr2/util/Timestamp.hpp"
 
-#include <gdal_priv.h>
+#include <gdal/gdal_priv.h>
 
 namespace lvr2
 {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ FetchContent_MakeAvailable(googletest)
 ###############################################################################
 list(APPEND LVR2_TEST_SOURCES
     test_bvh.cpp
+    test_basevector.cpp
 )
 
 if (embree_FOUND)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Use google test
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+###############################################################################
+# ADD TESTS HERE
+###############################################################################
+list(APPEND LVR2_TEST_SOURCES "")
+
+if (embree_FOUND)
+  list(APPEND LVR2_TEST_SOURCES test_embree.cpp)
+endif()
+
+add_executable(
+  lvr2_test
+  ${LVR2_TEST_SOURCES}
+)
+target_link_libraries(
+  lvr2_test
+  GTest::gtest_main
+  # Prefer static linking in tests
+  lvr2_static
+)
+
+include(GoogleTest)
+gtest_discover_tests(lvr2_test)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,7 +12,9 @@ FetchContent_MakeAvailable(googletest)
 ###############################################################################
 # ADD TESTS HERE
 ###############################################################################
-list(APPEND LVR2_TEST_SOURCES "")
+list(APPEND LVR2_TEST_SOURCES
+    test_bvh.cpp
+)
 
 if (embree_FOUND)
   list(APPEND LVR2_TEST_SOURCES test_embree.cpp)

--- a/src/tests/test_basevector.cpp
+++ b/src/tests/test_basevector.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+#include <lvr2/geometry/BaseVector.hpp>
+#include <lvr2/types/MatrixTypes.hpp>
+
+TEST(BaseVector, EigenConversions) {
+    const lvr2::BaseVector<float> bv(1.5f, -2.0f, 3.14f);
+    const lvr2::Vector3f vec = static_cast<lvr2::Vector3f>(bv);
+
+    ASSERT_FLOAT_EQ(vec.x(), 1.5f);
+    ASSERT_FLOAT_EQ(vec.y(), -2.0f);
+    ASSERT_FLOAT_EQ(vec.z(), 3.14f);
+
+    // Convert back
+    const lvr2::BaseVector<float> new_bv = vec;
+    ASSERT_FLOAT_EQ(new_bv.x, 1.5f);
+    ASSERT_FLOAT_EQ(new_bv.y, -2.0f);
+    ASSERT_FLOAT_EQ(new_bv.z, 3.14f);
+}
+

--- a/src/tests/test_bvh.cpp
+++ b/src/tests/test_bvh.cpp
@@ -1,0 +1,48 @@
+#include <optional>
+#include <gtest/gtest.h>
+#include <lvr2/algorithm/ClosestSurfacePoint.hpp>
+#include <lvr2/algorithm/raycasting/BVHRaycaster.hpp>
+#include <lvr2/algorithm/raycasting/Intersection.hpp>
+#include <lvr2/types/MatrixTypes.hpp>
+#include <lvr2/types/MeshBuffer.hpp>
+#include <lvr2/util/Synthetic.hpp>
+
+TEST(BVHClosestPoint, EmptyMesh) {
+    // An BVHRaycaster build from an empty mesh should always
+    // return std::nullopt as the closest point
+    
+    const lvr2::MeshBufferPtr mesh = std::make_shared<lvr2::MeshBuffer>();
+    const auto raycaster = std::make_unique<lvr2::BVHRaycaster<lvr2::AllInt>>(mesh);
+
+    const lvr2::Vector3f query = lvr2::Vector3f::Ones();
+    ASSERT_EQ(raycaster->getClosestPoint(query), std::nullopt);
+}
+
+TEST(BVHClosestPoint, Sphere) {
+    // A BVHRaycaster build from a valid mesh should return a valid point.
+    // On a unit sphere we also know the closest point pretty well.
+    // The sphere has some approximation error due to mesh discretization,
+    // therefore we only test for mm accuracy below.
+    
+    // NOTE: The default sphere discretization is way to low!
+    const lvr2::MeshBufferPtr mesh = lvr2::synthetic::genSphere(360, 360);
+    const auto raycaster = std::make_unique<lvr2::BVHRaycaster<lvr2::AllInt>>(mesh);
+
+    // X-Axis
+    const lvr2::Vector3f queryX = lvr2::Vector3f(2.0, 0.0, 0.0);
+    const std::optional<lvr2::ClosestSurfacePointQueryResult> resultX = raycaster->getClosestPoint(queryX);
+    ASSERT_TRUE(resultX.has_value());
+    ASSERT_LT((resultX.value().point - lvr2::Vector3f(1.0, 0.0, 0.0)).norm(), 0.001);
+
+    // Y-Axis
+    const lvr2::Vector3f queryY = lvr2::Vector3f(0.0, 2.0, 0.0);
+    const std::optional<lvr2::ClosestSurfacePointQueryResult> resultY = raycaster->getClosestPoint(queryY);
+    ASSERT_TRUE(resultY.has_value());
+    ASSERT_LT((resultY.value().point - lvr2::Vector3f(0.0, 1.0, 0.0)).norm(), 0.001);
+
+    // Z-Axis
+    const lvr2::Vector3f queryZ = lvr2::Vector3f(0.0, 0.0, 2.0);
+    const std::optional<lvr2::ClosestSurfacePointQueryResult> resultZ = raycaster->getClosestPoint(queryZ);
+    ASSERT_TRUE(resultZ.has_value());
+    ASSERT_LT((resultZ.value().point - lvr2::Vector3f(0.0, 0.0, 1.0)).norm(), 0.001);
+}

--- a/src/tests/test_embree.cpp
+++ b/src/tests/test_embree.cpp
@@ -1,0 +1,48 @@
+#include <optional>
+#include <gtest/gtest.h>
+#include <lvr2/algorithm/ClosestSurfacePoint.hpp>
+#include <lvr2/algorithm/raycasting/EmbreeRaycaster.hpp>
+#include <lvr2/algorithm/raycasting/Intersection.hpp>
+#include <lvr2/types/MatrixTypes.hpp>
+#include <lvr2/types/MeshBuffer.hpp>
+#include <lvr2/util/Synthetic.hpp>
+
+TEST(EmbreeClosestPoint, EmptyMesh) {
+    // An EmbreeRaycaster build from an empty mesh should always
+    // return std::nullopt as the closest point
+    
+    const lvr2::MeshBufferPtr mesh = std::make_shared<lvr2::MeshBuffer>();
+    const auto raycaster = std::make_unique<lvr2::EmbreeRaycaster<lvr2::AllInt>>(mesh);
+
+    const lvr2::Vector3f query = lvr2::Vector3f::Ones();
+    ASSERT_EQ(raycaster->getClosestPoint(query), std::nullopt);
+}
+
+TEST(EmbreeClosestPoint, Sphere) {
+    // An EmbreeRaycaster from a valid mesh should return a valid point.
+    // On a unit sphere we also know the closest point pretty well.
+    // The sphere has some approximation error due to mesh discretization,
+    // therefore we only test for mm accuracy below.
+    
+    // NOTE: The default sphere discretization is way to low!
+    const lvr2::MeshBufferPtr mesh = lvr2::synthetic::genSphere(360, 360);
+    const auto raycaster = std::make_unique<lvr2::EmbreeRaycaster<lvr2::AllInt>>(mesh);
+
+    // X-Axis
+    const lvr2::Vector3f queryX = lvr2::Vector3f(2.0, 0.0, 0.0);
+    const std::optional<lvr2::ClosestSurfacePointQueryResult> resultX = raycaster->getClosestPoint(queryX);
+    ASSERT_TRUE(resultX.has_value());
+    ASSERT_LT((resultX.value().point - lvr2::Vector3f(1.0, 0.0, 0.0)).norm(), 0.001);
+
+    // Y-Axis
+    const lvr2::Vector3f queryY = lvr2::Vector3f(0.0, 2.0, 0.0);
+    const std::optional<lvr2::ClosestSurfacePointQueryResult> resultY = raycaster->getClosestPoint(queryY);
+    ASSERT_TRUE(resultY.has_value());
+    ASSERT_LT((resultY.value().point - lvr2::Vector3f(0.0, 1.0, 0.0)).norm(), 0.001);
+
+    // Z-Axis
+    const lvr2::Vector3f queryZ = lvr2::Vector3f(0.0, 0.0, 2.0);
+    const std::optional<lvr2::ClosestSurfacePointQueryResult> resultZ = raycaster->getClosestPoint(queryZ);
+    ASSERT_TRUE(resultZ.has_value());
+    ASSERT_LT((resultZ.value().point - lvr2::Vector3f(0.0, 0.0, 1.0)).norm(), 0.001);
+}


### PR DESCRIPTION
This PR adds a new `IClosestSurfacePointQuery` interface to find the closest surface point on a mesh for arbitrary points in space. I also added two implementations, one using embree's BVH acceleration inside the `EmbreeRaycaster` and one using the lvr2 BVH tree in the `BVHRaycaster`.

In general I would prefer to separate the creation of the BVH structure and the raycasting / closest point query algorithms but that would require a larger refactor and would be a breaking change.

I also setup testing with gtest, which we could extend in the future, fixed some compiler warnings, and created operators to easily convert between lvr2::BaseVector and lvr2::Vector3 instances.